### PR TITLE
Fix signal server initialization

### DIFF
--- a/Backend/src/server.ts
+++ b/Backend/src/server.ts
@@ -1,5 +1,6 @@
 import { WebSocketServer, WebSocket } from "ws"
 import { randomBytes } from "crypto"
+import type { Server } from "http"
 
 // Types
 type Role = "sender" | "receiver"
@@ -47,74 +48,75 @@ function removeFromRoom(c: Client) {
 }
 
 // ---- WebSocket server ----
-const PORT = Number(process.env.PORT || 8787)
-const wss = new WebSocketServer({ port: PORT })
+export function createWSServer(server: Server) {
+  const wss = new WebSocketServer({ server })
 
-wss.on("connection", (ws: WebSocket) => {
-  const c: Client = { ws, isAlive: true }
+  wss.on("connection", (ws: WebSocket) => {
+    const c: Client = { ws, isAlive: true }
 
-  ws.on("pong", () => { c.isAlive = true })
+    ws.on("pong", () => { c.isAlive = true })
 
-  ws.on("message", (raw: Buffer) => {
-    let m: any
-    try { m = JSON.parse(String(raw)) } catch { return }
+    ws.on("message", (raw: Buffer) => {
+      let m: any
+      try { m = JSON.parse(String(raw)) } catch { return }
 
-    if (m.t === "create_room") {
-      const code = rid(4)
-      rooms[code] ||= new Map()
-      c.room = code
-      c.peerId = pid()
-      c.role = m.role as Role
-      rooms[code].set(c.peerId, c)
-      ws.send(JSON.stringify({ t: "room_created", roomCode: code, peerId: c.peerId }))
-      return
-    }
+      if (m.t === "create_room") {
+        const code = rid(4)
+        rooms[code] ||= new Map()
+        c.room = code
+        c.peerId = pid()
+        c.role = m.role as Role
+        rooms[code].set(c.peerId, c)
+        ws.send(JSON.stringify({ t: "room_created", roomCode: code, peerId: c.peerId }))
+        return
+      }
 
-    if (m.t === "join_room") {
-      const room = rooms[m.roomCode]
-      if (!room) { ws.send(JSON.stringify({ t: "error", msg: "bad_room" })); return }
-      c.room = m.roomCode
-      c.peerId = pid()
-      c.role = m.role as Role
-      room.set(c.peerId, c)
-      const members = [...room.entries()]
-        .filter(([id]) => id !== c.peerId)
-        .map(([peerId, cl]) => ({ peerId, role: cl.role! }))
-      ws.send(JSON.stringify({ t: "room_joined", peerId: c.peerId, members }))
-      broadcast(room, { t: "peer_joined", peerId: c.peerId, role: c.role }, c.peerId)
-      return
-    }
+      if (m.t === "join_room") {
+        const room = rooms[m.roomCode]
+        if (!room) { ws.send(JSON.stringify({ t: "error", msg: "bad_room" })); return }
+        c.room = m.roomCode
+        c.peerId = pid()
+        c.role = m.role as Role
+        room.set(c.peerId, c)
+        const members = [...room.entries()]
+          .filter(([id]) => id !== c.peerId)
+          .map(([peerId, cl]) => ({ peerId, role: cl.role! }))
+        ws.send(JSON.stringify({ t: "room_joined", peerId: c.peerId, members }))
+        broadcast(room, { t: "peer_joined", peerId: c.peerId, role: c.role }, c.peerId)
+        return
+      }
 
-    if (m.t === "leave_room") {
-      removeFromRoom(c)
-      return
-    }
+      if (m.t === "leave_room") {
+        removeFromRoom(c)
+        return
+      }
 
-    // Relay signaling + control
-    if (["offer","answer","ice","approve_join","request_send","grant_send","deny_send","transfer_release"].includes(m.t)) {
-      const room = rooms[m.roomCode]; if (!room) return
-      const target = room.get(m.to as string); if (!target) return
-      try { target.ws.send(JSON.stringify(m)) } catch {}
-      return
-    }
+      // Relay signaling + control
+      if (["offer","answer","ice","approve_join","request_send","grant_send","deny_send","transfer_release"].includes(m.t)) {
+        const room = rooms[m.roomCode]; if (!room) return
+        const target = room.get(m.to as string); if (!target) return
+        try { target.ws.send(JSON.stringify(m)) } catch {}
+        return
+      }
+    })
+
+    ws.on("close", () => { removeFromRoom(c) })
   })
 
-  ws.on("close", () => { removeFromRoom(c) })
-})
-
-// Heartbeat to drop dead sockets and notify peers
-setInterval(() => {
-  for (const room of Object.values(rooms)) {
-    for (const cl of room.values()) {
-      if (!cl.isAlive) {
-        try { cl.ws.terminate() } catch {}
-        removeFromRoom(cl)
-        continue
+  // Heartbeat to drop dead sockets and notify peers
+  setInterval(() => {
+    for (const room of Object.values(rooms)) {
+      for (const cl of room.values()) {
+        if (!cl.isAlive) {
+          try { cl.ws.terminate() } catch {}
+          removeFromRoom(cl)
+          continue
+        }
+        cl.isAlive = false
+        try { cl.ws.ping() } catch {}
       }
-      cl.isAlive = false
-      try { cl.ws.ping() } catch {}
     }
-  }
-}, 10_000)
+  }, 10_000)
 
-console.log(`ws://localhost:${PORT}`)
+  return wss
+}


### PR DESCRIPTION
## Summary
- export `createWSServer` function and wire heartbeat inside
- allow HTTP server to attach WebSocket signaling server

## Testing
- `npm run build` (backend)
- `npm run lint` (frontend) *(fails: Unexpected any, missing deps, etc)*
- `npm run build` (frontend) *(fails: unused React imports, type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b825f267248331a2cc3d09224fe23a