### PR TITLE
chore: restrict room actions until connected

### DIFF
--- a/Frontend/src/components/CreateJoin.tsx
+++ b/Frontend/src/components/CreateJoin.tsx
@@ -3,7 +3,12 @@ import { useSignal } from "../hooks/useSignal"
 
 export default function CreateJoin({ signal }:{ signal: ReturnType<typeof useSignal> }) {
   const [code, setCode] = useState("")
-  const canUse = ["open","mock","connecting"].includes(signal.status)
+  // Only allow create/join actions once the signalling channel is fully
+  // connected (or in mock mode). Previously the buttons were enabled while
+  // the websocket was still handshaking which could leave the UI stuck in a
+  // perpetual "Connecting" state after creating a room. Restricting actions
+  // avoids that confusing behaviour.
+  const canUse = signal.status === "open" || signal.status === "mock"
 
   return (
     <div className="card grid" style={{ gap:16 }}>


### PR DESCRIPTION
## Summary
- prevent creating or joining rooms until signalling channel is connected

## Testing
- `npm --prefix Frontend run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b825bc12c08331bff078a209859293